### PR TITLE
fix AXWebViewController 子类找不到资源文件

### DIFF
--- a/AXWebViewController/AXWebViewController/AXWebViewController.m
+++ b/AXWebViewController/AXWebViewController/AXWebViewController.m
@@ -655,7 +655,7 @@ BOOL AX_WEB_VIEW_CONTROLLER_iOS10_0_AVAILABLE() { return AX_WEB_VIEW_CONTROLLER_
 
 - (NSBundle *)resourceBundle{
     if (_resourceBundle) return _resourceBundle;
-    NSBundle *bundle = [NSBundle bundleForClass:[self class]];
+    NSBundle *bundle = [NSBundle bundleForClass:AXWebViewController.class];
     
     NSString *resourcePath = [bundle pathForResource:@"AXWebViewController" ofType:@"bundle"] ;
     


### PR DESCRIPTION
使用 Cocoapods 集成，并开启 user_frameworks 。主工程继承了 AXWebViewController 做了一些配置，这时候 [self class] 是继承后的子类，bundle 是 mainBundle 会导致找不到资源 bundle 文件。